### PR TITLE
ReactDOM.render周りのバグ修正とタグ入力周りのバグ修正

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -8,11 +8,3 @@
 // layout file, like app/views/layouts/application.html.erb
 
 console.log('Hello World from Webpacker')
-require('./toppage.jsx')
-require('./uploadpage.jsx')
-require('./folderpage.jsx')
-require('./header.jsx')
-require('./userpage.jsx')
-require('./edit_folder_page.jsx')
-require('./tags_page.jsx')
-require('./tag_page.jsx')

--- a/app/javascript/packs/components/input_tag.jsx
+++ b/app/javascript/packs/components/input_tag.jsx
@@ -56,7 +56,7 @@ class InputTag extends React.Component {
     addTag(input) {
         var tags = this.state.tags;
         if (input === '') return;
-        var inputTag = input.split(' ').filter((x, i, self) => self.indexOf(x) === i);
+        var inputTag = input.trim().replace(/\s+/g, ' ').split(' ').filter((x, i, self) => self.indexOf(x) === i);
         if (tags.length > 0) {
             tags = [...tags, ...inputTag].filter((x, i, self) => self.indexOf(x) === i);
         } else {
@@ -114,7 +114,6 @@ class InputTag extends React.Component {
                 />
             );
         }
-        var test = "aaa";
         const selectTags = this.state.selectTags.filter((x, i, self) => {
             return !tags.includes(x.name) &&
                 x.name.startsWith(this.state.input);

--- a/app/javascript/packs/components/upload_form.jsx
+++ b/app/javascript/packs/components/upload_form.jsx
@@ -198,6 +198,7 @@ class UploadForm extends React.Component {
     }
 
     componentDidMount() {
+        if (this.props.editMode) return;
         fetch('./slack_channels', { method: 'get' }).then(response => {
             return response.json();
         }).then(data => {


### PR DESCRIPTION
タグ入力時に連続するスペースや文字列前後にスペースが含まれていた場合、スペースがタグとして追加されてしまう問題をついでに解決しました。